### PR TITLE
Fix bounds for pruned leaves

### DIFF
--- a/R/forde.R
+++ b/R/forde.R
@@ -160,10 +160,13 @@ forde <- function(
       right_child <- arf$forest$child.nodeIDs[[tree]][[2]][i] + 1L
       splitvarID <- arf$forest$split.varIDs[[tree]][i] + 1L
       splitval <- arf$forest$split.value[[tree]][i]
-      if (left_child > 1 & left_child != right_child) {
+      if (left_child > 1) {
         ub[left_child, ] <- ub[right_child, ] <- ub[i, ]
         lb[left_child, ] <- lb[right_child, ] <- lb[i, ]
-        ub[left_child, splitvarID] <- lb[right_child, splitvarID] <- splitval
+        if (left_child != right_child) {
+          # If no pruned node, split changes bounds
+          ub[left_child, splitvarID] <- lb[right_child, splitvarID] <- splitval
+        }
       }
     }
     leaves <- which(arf$forest$child.nodeIDs[[tree]][[1]] == 0L) 

--- a/man/adversarial_rf.Rd
+++ b/man/adversarial_rf.Rd
@@ -6,10 +6,10 @@
 \usage{
 adversarial_rf(
   x,
-  num_trees = 10,
-  min_node_size = 2,
+  num_trees = 10L,
+  min_node_size = 2L,
   delta = 0,
-  max_iters = 10,
+  max_iters = 10L,
   verbose = TRUE,
   parallel = TRUE,
   ...


### PR DESCRIPTION
Before, at a pruned node the bounds from the parents were not copied, thereby deleting all bounds at a pruned node. Now the parents bounds are always preserved and new bounds only introduced if the node is not pruned.