### PR TITLE
Rename vignette to suit convention

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^arf\.Rcheck$
 ^arf.*\.tar\.gz$
 ^arf.*\.tgz$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ arf*.tgz
 *.DS_Store
 attic/
 branch/
+/doc/
+/Meta/

--- a/vignettes/arf.Rmd
+++ b/vignettes/arf.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Package Vignette"
+title: "Adversarial Random Forests"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Density Estimation}
+  %\VignetteIndexEntry{Adversarial Random Forests}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
This minor changes ensures that

- The vignette has a consistent title, filename and vignette index entry
- pkgdown links it in the navbar (because the filename is equal to the package name)