### PR TITLE
Evidence with NAs for imputation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arf
 Title: Adversarial Random Forests
-Version: 0.2.0
+Version: 0.2.1
 Date: 2024-01-24
 Authors@R: 
     c(person(given = "Marvin N.",

--- a/R/forge.R
+++ b/R/forge.R
@@ -113,7 +113,7 @@ forge <- function(
     draws <- omega[, sample(f_idx, size = n_synth, replace = TRUE, prob = wt), by = row_idx]
     setnames(draws, 'V1', 'f_idx')
   }
-  omega <- merge(draws, omega, sort = FALSE)[, idx := .I]
+  omega <- merge(draws, omega, by = c("row_idx", "f_idx"), sort = FALSE)[, idx := .I]
   
   # Simulate continuous data
   synth_cnt <- synth_cat <- NULL

--- a/R/forge.R
+++ b/R/forge.R
@@ -99,6 +99,7 @@ forge <- function(
     omega <- params$forest[, .(f_idx, cvg)]
     omega[, wt := cvg / num_trees]
     omega[, cvg := NULL]
+    omega[, row_idx := 1]
   } else if (isTRUE(conj)) {
     omega <- leaf_posterior(params, evidence)
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -115,7 +115,7 @@ prep_evi <- function(params, evidence) {
     }
     evidence[, row_idx := .I]
     evidence <- suppressWarnings(
-      melt(evidence, id.vars = "row_idx", variable.factor = FALSE)
+      melt(evidence, id.vars = "row_idx", variable.factor = FALSE, na.rm = TRUE)
     )
     evidence[, relation := '==']
     conj <- TRUE

--- a/R/utils.R
+++ b/R/utils.R
@@ -266,8 +266,9 @@ leaf_posterior <- function(params, evidence) {
     out <- unique(psi[, .(f_idx)])
     out[, wt := 1]
   }
-  out[, n := .N, by = .(row_idx)]
-  out[, wt := (wt / max(wt, na.rm = T))^(n + 1), by = row_idx][wt > 0, wt := wt / sum(wt), by = row_idx]
+  evi_n <- evidence[, .N, by = .(row_idx)]
+  out <- merge(out, evi_n, by = "row_idx")
+  out[, wt := (wt / max(wt, na.rm = T))^(N + 1), by = row_idx][wt > 0, wt := wt / sum(wt), by = row_idx]
   return(out[, .(f_idx, row_idx, wt)])
 }
 


### PR DESCRIPTION
Based on #17 but allows NAs in input for imputation. Still some bugs for other condition types and uses `dplyr::rows_patch` (not in imports).

Example: 
````R
library(arf)

arf <- adversarial_rf(iris)
psi <- forde(arf,iris)

evi <- iris
evi[1, 2] <- NA
evi[2, 1] <- NA

forge(psi, 1, evidence = evi)
````