### PR TITLE
Excpt ranges

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: arf
 Title: Adversarial Random Forests
 Version: 0.2.2
-Date: 2024-05-24
+Date: 2024-05-29
 Authors@R: 
     c(person(given = "Marvin N.",
              family = "Wright",

--- a/R/expct.R
+++ b/R/expct.R
@@ -33,6 +33,9 @@
 #' distribution over leaves, with columns \code{f_idx} and \code{wt}. This may 
 #' be preferable for complex constraints. See Examples.
 #' 
+#' Please note that results for continuous features which are both included in \code{query} and in
+#' \code{evidence} with an interval condition are currently inconsistent.
+#' 
 #' @return 
 #' A one row data frame with values for all query variables.
 #' 
@@ -122,7 +125,11 @@ expct <- function(
   
   # Check query
   if (is.null(query)) {
-    query <- params$meta$variable
+    if (any(is.na(evidence))) {
+      query <- params$meta$variable
+    } else {
+      query <- setdiff(params$meta$variable, colnames(evidence))
+    }
   } else if (any(!query %in% params$meta$variable)) {
     err <- setdiff(query, params$meta$variable)
     stop('Unrecognized feature(s) in query: ', err)

--- a/R/expct.R
+++ b/R/expct.R
@@ -144,7 +144,7 @@ expct <- function(
       index_start <- (step_-1)*stepsize + 1
       index_end <- min(step_*stepsize, nrow(evidence))
       evidence_part <- evidence[index_start:index_end,]
-      cparams <- cforde(params, evidence_part, evidence_row_mode, stepsize_cforde, parallel_cforde)
+      cparams <- arf:::cforde(params, evidence_part, evidence_row_mode, stepsize_cforde, parallel_cforde)
     } 
     
     # omega contains the weight (wt) for each leaf (f_idx) for each condition (c_idx)
@@ -173,17 +173,18 @@ expct <- function(
       } else {
         psi_cond <- merge(omega, cparams$cnt[variable %in% query, -c("cvg_factor", "f_idx_uncond")], by = c('c_idx', 'f_idx'), 
                           sort = FALSE, allow.cartesian = TRUE)[prob > 0,]
-        # draw sub-leaf areas (resulting from within-row or-conditions)
+        # calculate absolute weights for sub-leaf areas (resulting from within-row or-conditions)
         if(any(psi_cond[,prob != 1])) {
-          psi_cond[, I := .I]
-          psi_cond <- psi_cond[sort(c(psi_cond[prob == 1, I],
-                                      psi_cond[prob > 0 & prob < 1, fifelse(.N > 1, resample(I, 1, prob = prob), 0), by = .(variable, idx)][,V1])), -"I"]
+          psi_cond[, wt := wt*prob]
+          psi_cond[, I := seq_len(.N), by = .(variable, idx)]
+        } else {
+          psi_cond[, I := 1]
         }
         psi_cond[, prob := NULL]
       } 
       psi <- unique(rbind(psi_cond,
                           merge(omega, params$cnt[variable %in% query, ], by.x = 'f_idx_uncond', by.y = 'f_idx',
-                                sort = FALSE, allow.cartesian = TRUE)[,val := NA_real_]), by = c("c_idx", "f_idx", "variable"))
+                                sort = FALSE, allow.cartesian = TRUE)[,`:=` (val = NA_real_, I = 1)]), by = c("c_idx", "f_idx", "variable", "I"))[, I := NULL]
       psi[NA_share == 1, wt := 0]
       cnt <- psi[is.na(val), val := sum(wt * mu)/sum(wt), by = .(c_idx, variable)]
       cnt <- unique(cnt[, .(c_idx, variable, val)])

--- a/R/expct.R
+++ b/R/expct.R
@@ -140,7 +140,7 @@ expct <- function(
       index_start <- (step_-1)*stepsize + 1
       index_end <- min(step_*stepsize, nrow(evidence))
       evidence_part <- evidence[index_start:index_end,]
-      cparams <- arf:::cforde(params, evidence_part, evidence_row_mode, stepsize_cforde, parallel_cforde)
+      cparams <- cforde(params, evidence_part, evidence_row_mode, stepsize_cforde, parallel_cforde)
     } 
     
     # omega contains the weight (wt) for each leaf (f_idx) for each condition (c_idx)

--- a/R/expct.R
+++ b/R/expct.R
@@ -122,11 +122,7 @@ expct <- function(
   
   # Check query
   if (is.null(query)) {
-    if (any(is.na(evidence))) {
-      query <- params$meta$variable
-    } else {
-      query <- setdiff(params$meta$variable, colnames(evidence))
-    }
+    query <- params$meta$variable
   } else if (any(!query %in% params$meta$variable)) {
     err <- setdiff(query, params$meta$variable)
     stop('Unrecognized feature(s) in query: ', err)

--- a/man/expct.Rd
+++ b/man/expct.Rd
@@ -55,6 +55,9 @@ provide a data frame with condition events. This supports inequalities and inter
 Alternatively, users may directly input a pre-calculated posterior
 distribution over leaves, with columns \code{f_idx} and \code{wt}. This may
 be preferable for complex constraints. See Examples.
+
+Please note that results for continuous features which are both included in \code{query} and in
+\code{evidence} with an interval condition are currently inconsistent.
 }
 \examples{
 # Train ARF and estimate leaf parameters

--- a/tests/testthat/test_expct.R
+++ b/tests/testthat/test_expct.R
@@ -40,14 +40,14 @@ test_that("expct works with partial sample", {
   res <- expct(psi, evidence = evi, parallel = FALSE)
   expect_s3_class(res, "data.frame")
   expect_equal(nrow(res), nrow(evi))
-  expect_equal(ncol(res), ncol(iris))
-  expect_equal(colnames(res), colnames(iris))
+  expect_equal(ncol(res), ncol(iris) - ncol(evi))
+  expect_equal(colnames(res), colnames(iris)[3:4])
   
   # Petal.* and Species missing
   evi <- iris[1:3, 1:2]
   res <- expct(psi, evidence = evi, parallel = FALSE)
   expect_s3_class(res, "data.frame")
   expect_equal(nrow(res), nrow(evi))
-  expect_equal(ncol(res), ncol(iris))
-  expect_equal(colnames(res), colnames(iris))
+  expect_equal(ncol(res), ncol(iris) - ncol(evi))
+  expect_equal(colnames(res), colnames(iris)[3:5])
 })

--- a/tests/testthat/test_expct.R
+++ b/tests/testthat/test_expct.R
@@ -40,14 +40,14 @@ test_that("expct works with partial sample", {
   res <- expct(psi, evidence = evi, parallel = FALSE)
   expect_s3_class(res, "data.frame")
   expect_equal(nrow(res), nrow(evi))
-  expect_equal(ncol(res), ncol(iris) - ncol(evi))
-  expect_equal(colnames(res), colnames(iris)[3:4])
+  expect_equal(ncol(res), ncol(iris))
+  expect_equal(colnames(res), colnames(iris))
   
   # Petal.* and Species missing
   evi <- iris[1:3, 1:2]
   res <- expct(psi, evidence = evi, parallel = FALSE)
   expect_s3_class(res, "data.frame")
   expect_equal(nrow(res), nrow(evi))
-  expect_equal(ncol(res), ncol(iris) - ncol(evi))
-  expect_equal(colnames(res), colnames(iris)[3:5])
+  expect_equal(ncol(res), ncol(iris))
+  expect_equal(colnames(res), colnames(iris))
 })


### PR DESCRIPTION
- Handle discountinuous intra-leaf regions (resulting from within-row OR-condtions for continuous variables) correctly (no intra-leaf sampling)
- Avoid different handling of partial evidence vectors with NULL-queries (does not make sense for range-conditions, these variables would be excluded from output). With this PR, all variables will always be chosen for query if is.NULL(query). Alternatively, range conditions would have to be detected and handled seperately. If desired, implement in new PR.