### PR TITLE
Add nomatch argument

### DIFF
--- a/R/expct.R
+++ b/R/expct.R
@@ -17,6 +17,10 @@
 #'   each row in \code{evidence} is a separate conditioning event for which \code{n_synth} synthetic samples
 #'   are generated. If \code{'or'}, the rows are combined with a logical or; see Examples.
 #' @param round Round continuous variables to their respective maximum precision in the real data set?
+#' @param nomatch What to do if no leaf matches a condition in \code{evidence}?
+#'   Options are to force sampling from a random leaf, either with a warning (\code{"force_warning"})
+#'   or without a warning (\code{"force"}), or to return \code{NA}, also with a warning 
+#'   (\code{"na_warning"}) or without a warning (\code{"na"}). The default is \code{"force_warning"}.
 #' @param stepsize Stepsize defining number of evidence rows handled in one for each step.
 #'   Defaults to nrow(evidence)/num_registered_workers for \code{parallel == TRUE}.
 #' @param parallel Compute in parallel? Must register backend beforehand, e.g. 
@@ -85,6 +89,7 @@ expct <- function(
     evidence = NULL,
     evidence_row_mode = c("separate", "or"),
     round = FALSE,
+    nomatch = c("force_warning", "force", "na_warning", "na"),
     stepsize = 0,
     parallel = TRUE) {
   
@@ -149,7 +154,7 @@ expct <- function(
       index_start <- (step_-1)*stepsize + 1
       index_end <- min(step_*stepsize, nrow(evidence))
       evidence_part <- evidence[index_start:index_end,]
-      cparams <- cforde(params, evidence_part, evidence_row_mode, stepsize_cforde, parallel_cforde)
+      cparams <- cforde(params, evidence_part, evidence_row_mode, nomatch, stepsize_cforde, parallel_cforde)
     } 
     
     # omega contains the weight (wt) for each leaf (f_idx) for each condition (c_idx)

--- a/R/expct.R
+++ b/R/expct.R
@@ -94,6 +94,7 @@ expct <- function(
     parallel = TRUE) {
   
   evidence_row_mode <- match.arg(evidence_row_mode)
+  nomatch <- match.arg(nomatch)
   
   # To avoid data.table check issues
   variable <- tree <- f_idx <- cvg <- wt <- V1 <- value <- val <- family <-

--- a/R/forge.R
+++ b/R/forge.R
@@ -111,6 +111,7 @@ forge <- function(
     parallel = TRUE) {
   
   evidence_row_mode <- match.arg(evidence_row_mode)
+  nomatch <- match.arg(nomatch)
   
   # To avoid data.table check issues
   tree <- cvg <- leaf <- idx <- family <- mu <- sigma <- prob <- dat <- 
@@ -180,15 +181,6 @@ forge <- function(
       omega <- cparams$forest[, .(c_idx, f_idx, f_idx_uncond, wt = cvg)]
     } 
     omega <- omega[wt > 0, ]
-    
-    # Use random leaves if NA (no matching leaves found)
-    if (omega[, any(is.na(f_idx))] & omega[, any(!is.na(f_idx))]) {
-      row_idx <- sample(nrow(omega[!is.na(f_idx), ]), omega[, sum(is.na(f_idx))], replace = TRUE)
-      temp <- omega[!is.na(f_idx), ][row_idx, .(f_idx, f_idx_uncond)]
-      omega[is.na(f_idx), f_idx_uncond := temp[, f_idx_uncond]]
-      omega[is.na(f_idx), f_idx := temp[, f_idx]]
-    }
-    
     
     # For each synthetic sample and condition, draw a leaf according to the leaf weights
     if (nrow(omega) == 1) {

--- a/R/forge.R
+++ b/R/forge.R
@@ -13,6 +13,10 @@
 #'   are generated. If \code{'or'}, the rows are combined with a logical or; see Examples.
 #' @param round Round continuous variables to their respective maximum precision in the real data set?
 #' @param sample_NAs Sample NAs respecting the probability for missing values in the original data.
+#' @param nomatch What to do if no leaf matches a condition in \code{evidence}?
+#'   Options are to force sampling from a random leaf, either with a warning (\code{"force_warning"})
+#'   or without a warning (\code{"force"}), or to return \code{NA}, also with a warning 
+#'   (\code{"na_warning"}) or without a warning (\code{"na"}). The default is \code{"force_warning"}.
 #' @param stepsize Stepsize defining number of evidence rows handled in one for each step.
 #'   Defaults to nrow(evidence)/num_registered_workers for \code{parallel == TRUE}.
 #' @param parallel Compute in parallel? Must register backend beforehand, e.g. 
@@ -102,6 +106,7 @@ forge <- function(
     evidence_row_mode = c("separate", "or"),
     round = TRUE,
     sample_NAs = FALSE,
+    nomatch = c("force_warning", "force", "na_warning", "na"),
     stepsize = 0,
     parallel = TRUE) {
   
@@ -153,7 +158,7 @@ forge <- function(
       index_start <- (step_-1)*stepsize + 1
       index_end <- min(step_*stepsize, nrow(evidence))
       evidence_part <- evidence[index_start:index_end,]
-      cparams <- cforde(params, evidence_part, evidence_row_mode, stepsize_cforde, parallel_cforde)
+      cparams <- cforde(params, evidence_part, evidence_row_mode, nomatch, stepsize_cforde, parallel_cforde)
       if (is.null(cparams)) {
         n_synth <- n_synth * nrow(evidence_part)
       }

--- a/R/utils.R
+++ b/R/utils.R
@@ -428,7 +428,12 @@ cforde <- function(params,
       stop("For all entered evidence rows, no matching leaves could be found. This is probably because evidence lies outside of the distribution calculated by FORDE. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde(). For categorical data, consider setting alpha>0 in forde().")
     } else {
       if (grepl("warning$", nomatch)) {
-        warning("For some entered evidence rows, no matching leaves could be found. This is probably because evidence lies outside of the distribution calculated by FORDE. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde(). For categorical data, consider setting alpha>0 in forde().")
+        wrn <- "For some entered evidence rows, no matching leaves could be found. This is probably because evidence lies outside of the distribution calculated by FORDE. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde(). For categorical data, consider setting alpha>0 in forde()."
+        if (grepl("^force", nomatch)) {
+          warning(paste(wrn, "Sampling from all leaves with equal probability (can be changed with 'nomatch' argument)."))
+        } else {
+          warning(paste(wrn, "Returning NA for those rows (can be changed with 'nomatch' argument)."))
+        }
       }
       conds_impossible <- conds_conditioned[!(conds_conditioned %in% relevant_leaves[,unique(c_idx)])]
       relevant_leaves <- setorder(rbind(relevant_leaves, data.table(c_idx = conds_impossible, f_idx = NA_integer_, f_idx_uncond = NA_integer_)))
@@ -459,7 +464,12 @@ cforde <- function(params,
           cvg_new[, cvg := NA]
         }
         if (grepl("warning$", nomatch)) {
-          warning("All leaves have zero likelihood. This is probably because evidence contains an (almost) impossible combination. Sampling from all leaves with equal probability.")
+          wrn <- "All leaves have zero likelihood. This is probably because evidence contains an (almost) impossible combination."
+          if (grepl("^force", nomatch)) {
+            warning(paste(wrn, "Sampling from all possible leaves with equal probability."))
+          } else {
+            warning(paste(wrn, "Returning NA."))
+          }
         }
       } else {
         cvg_new[, cvg := exp(cvg - max(cvg))]
@@ -474,7 +484,12 @@ cforde <- function(params,
           cvg_new <- cvg_new[leaf_zero_lik == FALSE, ]
         }
         if (grepl("warning$", nomatch)) {
-          warning("All leaves have zero likelihood for some entered evidence rows. This is probably because evidence contains an (almost) impossible combination. Sampling from all leaves with equal probability.")
+          wrn <- "All leaves have zero likelihood for some entered evidence rows. This is probably because evidence contains an (almost) impossible combination."
+          if (grepl("^force", nomatch)) {
+            warning(paste(wrn, "Sampling from all possible leaves with equal probability (can be changed with 'nomatch' argument)."))
+          } else {
+            warning(paste(wrn, "Returning NA for those rows (can be changed with 'nomatch' argument)."))
+          }
         }
       }
       if (any(cvg_new[, !leaf_zero_lik])) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -436,7 +436,15 @@ cforde <- function(params,
         }
       }
       conds_impossible <- conds_conditioned[!(conds_conditioned %in% relevant_leaves[,unique(c_idx)])]
-      relevant_leaves <- setorder(rbind(relevant_leaves, data.table(c_idx = conds_impossible, f_idx = NA_integer_, f_idx_uncond = NA_integer_)))
+
+      if (grepl("^force", nomatch)) {
+        # All leaves 
+        impossible_leaves <- data.table(c_idx = conds_impossible, f_idx = forest$f_idx, f_idx_uncond = forest$f_idx)
+      } else {
+        # Set to NA -> no leaves -> Sample NA
+        impossible_leaves <- data.table(c_idx = conds_impossible, f_idx = NA_integer_, f_idx_uncond = NA_integer_)
+      }
+      relevant_leaves <- setorder(rbind(relevant_leaves, impossible_leaves))
     }
   }
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -226,6 +226,7 @@ cforde <- function(params,
                    parallel = TRUE) {
   
   row_mode <- match.arg(row_mode)
+  nomatch <- match.arg(nomatch)
   
   # To avoid data.table check issues
   . <- c_idx <- cvg <- cvg_arf <- cvg_factor <- f_idx <- f_idx_uncond <- i.max <-

--- a/man/cforde.Rd
+++ b/man/cforde.Rd
@@ -8,6 +8,7 @@ cforde(
   params,
   evidence,
   row_mode = c("separate", "or"),
+  nomatch = c("force_warning", "force", "na_warning", "na"),
   stepsize = 0,
   parallel = TRUE
 )
@@ -18,6 +19,11 @@ cforde(
 \item{evidence}{Data frame of conditioning event(s).}
 
 \item{row_mode}{Interpretation of rows in multi-row conditions.}
+
+\item{nomatch}{What to do if no leaf matches a condition in \code{evidence}?
+Options are to force sampling from a random leaf, either with a warning (\code{"force_warning"})
+or without a warning (\code{"force"}), or to return \code{NA}, also with a warning
+(\code{"na_warning"}) or without a warning (\code{"na"}). The default is \code{"force_warning"}.}
 
 \item{stepsize}{Stepsize defining number of condition rows handled in one for each step.}
 

--- a/man/expct.Rd
+++ b/man/expct.Rd
@@ -10,6 +10,7 @@ expct(
   evidence = NULL,
   evidence_row_mode = c("separate", "or"),
   round = FALSE,
+  nomatch = c("force_warning", "force", "na_warning", "na"),
   stepsize = 0,
   parallel = TRUE
 )
@@ -33,6 +34,11 @@ each row in \code{evidence} is a separate conditioning event for which \code{n_s
 are generated. If \code{'or'}, the rows are combined with a logical or; see Examples.}
 
 \item{round}{Round continuous variables to their respective maximum precision in the real data set?}
+
+\item{nomatch}{What to do if no leaf matches a condition in \code{evidence}?
+Options are to force sampling from a random leaf, either with a warning (\code{"force_warning"})
+or without a warning (\code{"force"}), or to return \code{NA}, also with a warning
+(\code{"na_warning"}) or without a warning (\code{"na"}). The default is \code{"force_warning"}.}
 
 \item{stepsize}{Stepsize defining number of evidence rows handled in one for each step.
 Defaults to nrow(evidence)/num_registered_workers for \code{parallel == TRUE}.}

--- a/man/forge.Rd
+++ b/man/forge.Rd
@@ -11,6 +11,7 @@ forge(
   evidence_row_mode = c("separate", "or"),
   round = TRUE,
   sample_NAs = FALSE,
+  nomatch = c("force_warning", "force", "na_warning", "na"),
   stepsize = 0,
   parallel = TRUE
 )
@@ -33,6 +34,11 @@ are generated. If \code{'or'}, the rows are combined with a logical or; see Exam
 \item{round}{Round continuous variables to their respective maximum precision in the real data set?}
 
 \item{sample_NAs}{Sample NAs respecting the probability for missing values in the original data.}
+
+\item{nomatch}{What to do if no leaf matches a condition in \code{evidence}?
+Options are to force sampling from a random leaf, either with a warning (\code{"force_warning"})
+or without a warning (\code{"force"}), or to return \code{NA}, also with a warning
+(\code{"na_warning"}) or without a warning (\code{"na"}). The default is \code{"force_warning"}.}
 
 \item{stepsize}{Stepsize defining number of evidence rows handled in one for each step.
 Defaults to nrow(evidence)/num_registered_workers for \code{parallel == TRUE}.}

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -30,14 +30,14 @@ test_that("if nomatch='force_warning', run through with a warning", {
   psi_no <- forde(arf, iris, finite_bounds = "no", parallel = FALSE)
   expect_warning(x_synth <- forge(psi_no, evidence = data.frame(Sepal.Length = 100), 
                                   nomatch = "force_warning", n_synth = 10, parallel = FALSE), 
-      "All leaves have zero likelihood for some entered evidence rows\\. This is probably because evidence contains an \\(almost\\) impossible combination\\. Sampling from all leaves with equal probability\\.")
+      "All leaves have zero likelihood for some entered evidence rows\\. This is probably because evidence contains an \\(almost\\) impossible combination\\. Sampling from all possible leaves with equal probability \\(can be changed with 'nomatch' argument\\)\\.")
   expect_true(all(!is.na(x_synth)))
   
   # No matching leaf case (finite bounds)
   psi_global <- forde(arf, iris, finite_bounds = "global", parallel = FALSE)
   expect_warning(x_synth <- forge(psi_global, evidence = data.frame(Sepal.Length = 100), 
                                   nomatch = "force_warning", n_synth = 10, parallel = FALSE), 
-                 "For some entered evidence rows, no matching leaves could be found\\. This is probably because evidence lies outside of the distribution calculated by FORDE\\. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde\\(\\)\\. For categorical data, consider setting alpha>0 in forde\\(\\)\\.")
+                 "For some entered evidence rows, no matching leaves could be found\\. This is probably because evidence lies outside of the distribution calculated by FORDE\\. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde\\(\\)\\. For categorical data, consider setting alpha>0 in forde\\(\\)\\. Sampling from all leaves with equal probability \\(can be changed with 'nomatch' argument\\)\\.")
   expect_true(all(!is.na(x_synth)))
 })
 
@@ -60,14 +60,14 @@ test_that("if nomatch='na_warning', run through with a warning and return NA", {
   psi_no <- forde(arf, iris, finite_bounds = "no", parallel = FALSE)
   expect_warning(x_synth <- forge(psi_no, evidence = data.frame(Sepal.Length = 100), 
                                   nomatch = "na_warning", n_synth = 10, parallel = FALSE), 
-                 "All leaves have zero likelihood for some entered evidence rows\\. This is probably because evidence contains an \\(almost\\) impossible combination\\. Sampling from all leaves with equal probability\\.")
+                 "All leaves have zero likelihood for some entered evidence rows\\. This is probably because evidence contains an \\(almost\\) impossible combination\\. Returning NA for those rows \\(can be changed with 'nomatch' argument\\)\\.")
   expect_true(all(is.na(x_synth[, -1])))
   
   # No matching leaf case (finite bounds)
   psi_global <- forde(arf, iris, finite_bounds = "global", parallel = FALSE)
   expect_warning(x_synth <- forge(psi_global, evidence = data.frame(Sepal.Length = 100), 
                                   nomatch = "na_warning", n_synth = 10, parallel = FALSE), 
-                 "For some entered evidence rows, no matching leaves could be found\\. This is probably because evidence lies outside of the distribution calculated by FORDE\\. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde\\(\\)\\. For categorical data, consider setting alpha>0 in forde\\(\\)\\.")
+                 "For some entered evidence rows, no matching leaves could be found\\. This is probably because evidence lies outside of the distribution calculated by FORDE\\. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde\\(\\)\\. For categorical data, consider setting alpha>0 in forde\\(\\)\\. Returning NA for those rows \\(can be changed with 'nomatch' argument\\)\\.")
   expect_true(all(is.na(x_synth[, -1])))
 })
 

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -25,3 +25,63 @@ test_that("categorical conditions work with not", {
   expect_in(as.character(synth$Species), c("versicolor", "virginica"))
 })
 
+test_that("if nomatch='force_warning', run through with a warning", {
+  # Zero likelihood case (no finite bounds)
+  psi_no <- forde(arf, iris, finite_bounds = "no", parallel = FALSE)
+  expect_warning(x_synth <- forge(psi_no, evidence = data.frame(Sepal.Length = 100), 
+                                  nomatch = "force_warning", n_synth = 10, parallel = FALSE), 
+      "All leaves have zero likelihood for some entered evidence rows\\. This is probably because evidence contains an \\(almost\\) impossible combination\\. Sampling from all leaves with equal probability\\.")
+  expect_true(all(!is.na(x_synth)))
+  
+  # No matching leaf case (finite bounds)
+  psi_global <- forde(arf, iris, finite_bounds = "global", parallel = FALSE)
+  expect_warning(x_synth <- forge(psi_global, evidence = data.frame(Sepal.Length = 100), 
+                                  nomatch = "force_warning", n_synth = 10, parallel = FALSE), 
+                 "For some entered evidence rows, no matching leaves could be found\\. This is probably because evidence lies outside of the distribution calculated by FORDE\\. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde\\(\\)\\. For categorical data, consider setting alpha>0 in forde\\(\\)\\.")
+  expect_true(all(!is.na(x_synth)))
+})
+
+test_that("if nomatch='force', run through without a warning", {
+  # Zero likelihood case (no finite bounds)
+  psi_no <- forde(arf, iris, finite_bounds = "no", parallel = FALSE)
+  expect_silent(x_synth <- forge(psi_no, evidence = data.frame(Sepal.Length = 100), 
+                                  nomatch = "force", n_synth = 10, parallel = FALSE))
+  expect_true(all(!is.na(x_synth)))
+  
+  # No matching leaf case (finite bounds)
+  psi_global <- forde(arf, iris, finite_bounds = "global", parallel = FALSE)
+  expect_silent(x_synth <- forge(psi_global, evidence = data.frame(Sepal.Length = 100), 
+                                  nomatch = "force", n_synth = 10, parallel = FALSE))
+  expect_true(all(!is.na(x_synth)))
+})
+
+test_that("if nomatch='na_warning', run through with a warning and return NA", {
+  # Zero likelihood case (no finite bounds)
+  psi_no <- forde(arf, iris, finite_bounds = "no", parallel = FALSE)
+  expect_warning(x_synth <- forge(psi_no, evidence = data.frame(Sepal.Length = 100), 
+                                  nomatch = "na_warning", n_synth = 10, parallel = FALSE), 
+                 "All leaves have zero likelihood for some entered evidence rows\\. This is probably because evidence contains an \\(almost\\) impossible combination\\. Sampling from all leaves with equal probability\\.")
+  expect_true(all(is.na(x_synth[, -1])))
+  
+  # No matching leaf case (finite bounds)
+  psi_global <- forde(arf, iris, finite_bounds = "global", parallel = FALSE)
+  expect_warning(x_synth <- forge(psi_global, evidence = data.frame(Sepal.Length = 100), 
+                                  nomatch = "na_warning", n_synth = 10, parallel = FALSE), 
+                 "For some entered evidence rows, no matching leaves could be found\\. This is probably because evidence lies outside of the distribution calculated by FORDE\\. For continuous data, consider setting epsilon>0 or finite_bounds='no' in forde\\(\\)\\. For categorical data, consider setting alpha>0 in forde\\(\\)\\.")
+  expect_true(all(is.na(x_synth[, -1])))
+})
+
+test_that("if nomatch='na', run through without a warning and return NA", {
+  # Zero likelihood case (no finite bounds)
+  psi_no <- forde(arf, iris, finite_bounds = "no", parallel = FALSE)
+  expect_silent(x_synth <- forge(psi_no, evidence = data.frame(Sepal.Length = 100), 
+                                 nomatch = "na", n_synth = 10, parallel = FALSE))
+  expect_true(all(is.na(x_synth[, -1])))
+  
+  # No matching leaf case (finite bounds)
+  psi_global <- forde(arf, iris, finite_bounds = "global", parallel = FALSE)
+  expect_silent(x_synth <- forge(psi_global, evidence = data.frame(Sepal.Length = 100), 
+                                 nomatch = "na", n_synth = 10, parallel = FALSE))
+  expect_true(all(is.na(x_synth[, -1])))
+})
+


### PR DESCRIPTION
The `nomatch` arguments controls what to do if no matching leaf was found (see docs).

Tests are still failing because "force" not yet implemented for the finite bound case. 