### PR TITLE
n_synth default with given evidence

### DIFF
--- a/R/forde.R
+++ b/R/forde.R
@@ -280,7 +280,7 @@ forde <- function(
         dt[NA_share == 1, c('min', 'max') := .(fifelse(is.infinite(min), min_emp, min),
                                                fifelse(is.infinite(max), max_emp, max))]
         dt[, c("min_emp", "max_emp") := NULL]
-        dt[NA_share == 1, mu := (max - min) / 2]
+        dt[NA_share == 1, mu := (max + min) / 2]
         dt[is.na(sigma), sigma := 0]
         if (any(dt[, sigma == 0])) {
           dt[, new_min := fifelse(!is.finite(min), min(value, na.rm = TRUE), min), by = variable]

--- a/R/shortcut_functions.R
+++ b/R/shortcut_functions.R
@@ -73,8 +73,12 @@ darf <- function(x, query = NULL, ...) {
 #' 
 #' @param x Input data. Integer variables are recoded as ordered factors with
 #'   a warning. See Details.
-#' @param n_synth Number of synthetic samples to generate. Is set to \code{nrow(x)} if
-#' \code{NULL}.
+#' @param n_synth Number of synthetic samples to generate for unconditional
+#' generation with no \code{evidence} given.
+#' Number of synthetic samples to generate per \code{evidence} row if \code{evidence}
+#' is provided.
+#' If \code{NULL}, defaults to \code{nrow(x)} if no \code{evidence} is provided and to
+#' \code{1} otherwise.
 #' @param ... Extra parameters to be passed to \code{adversarial_rf}, \code{forde}
 #'   and \code{forge}.
 #'   
@@ -122,7 +126,14 @@ rarf <- function(x, n_synth = NULL, ...) {
   
   if (!("params" %in% names(forde_args))) params <- do.call(forde, c(arf = list(arf), x = list(x), forde_args))
   
-  if(is.null(n_synth)) n_synth <- nrow(x)
+  if(is.null(n_synth)) {
+    if (is.null(forge_args$evidence))
+      n_synth <- nrow(x)
+    else {
+      n_synth <- 1
+    }
+  }
+  
   do.call(forge, c(params = list(params), 
                    n_synth = list(n_synth),
                    forge_args))

--- a/man/rarf.Rd
+++ b/man/rarf.Rd
@@ -10,8 +10,12 @@ rarf(x, n_synth = NULL, ...)
 \item{x}{Input data. Integer variables are recoded as ordered factors with
 a warning. See Details.}
 
-\item{n_synth}{Number of synthetic samples to generate. Is set to \code{nrow(x)} if
-\code{NULL}.}
+\item{n_synth}{Number of synthetic samples to generate for unconditional
+generation with no \code{evidence} given.
+Number of synthetic samples to generate per \code{evidence} row if \code{evidence}
+is provided.
+If \code{NULL}, defaults to \code{nrow(x)} if no \code{evidence} is provided and to
+\code{1} otherwise.}
 
 \item{...}{Extra parameters to be passed to \code{adversarial_rf}, \code{forde}
 and \code{forge}.}


### PR DESCRIPTION
Set default in rarf to 1 for n_synth if evidence is given. Adjust rarf documentation for n_synth.