### PR TITLE
forde oob cvg count fix

### DIFF
--- a/R/forde.R
+++ b/R/forde.R
@@ -243,6 +243,7 @@ forde <- function(
     keep <- unique(keep[, cnt := .N, by = .(tree, leaf)])
     keep[, n_oob := sum(oob), by = tree]
     keep[, cvg := cnt / n_oob][, c('oob', 'cnt', 'n_oob') := NULL]
+    keep[, cvg := cvg/sum(cvg), by = tree]
   } else if (oob == "inbag") {
     keep[, inbag := as.vector(sapply(seq_len(num_trees), function(b) {
       arf$inbag.counts[[b]][seq_len(n)] > 0L
@@ -251,6 +252,7 @@ forde <- function(
     keep <- unique(keep[, cnt := .N, by = .(tree, leaf)])
     keep[, n_inbag := sum(inbag), by = tree]
     keep[, cvg := cnt / n_inbag][, c('inbag', 'cnt', 'n_inbag') := NULL]
+    keep[, cvg := cvg/sum(cvg), by = tree]
   } else {
     keep <- unique(keep[, cnt := .N, by = .(tree, leaf)])
     keep[, cvg := cnt / n][, cnt := NULL]

--- a/tests/testthat/test-return_types.R
+++ b/tests/testthat/test-return_types.R
@@ -22,6 +22,16 @@ test_that("FORDE categories sum to unity", {
   expect_equal(tmp$V1, rep(1, times = tmp[, .N]))
 })
 
+test_that("FORDE coverages sum to number of trees", {
+  arf <- adversarial_rf(iris, num_trees = 2, verbose = FALSE, parallel = FALSE)
+  psi <- forde(arf, iris)
+  psi_oob <- forde(arf, iris, oob = TRUE)
+  psi_inbag <- forde(arf, iris, oob = "inbag")
+  expect_equal(psi$forest[, sum(cvg)], 2)
+  expect_equal(psi_oob$forest[, sum(cvg)], 2)
+  expect_equal(psi_inbag$forest[, sum(cvg)], 2)
+})
+
 test_that("Likelihood calculation returns vector of log-likelihoods", {
   arf <- adversarial_rf(iris, num_trees = 2, verbose = FALSE, parallel = FALSE)
   psi <- forde(arf, iris, parallel = FALSE)


### PR DESCRIPTION
Coverages did not sum to num_trees when oob = T or oob = "inbag" was used. Fix with this PR.