### PR TITLE
add mirai/mori proof of concept for forde()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^arf.*\.tgz$
 ^doc$
 ^Meta$
+^bench$

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ attic/
 branch/
 /doc/
 /Meta/
+bench/slurm/logs/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,8 @@ Suggests:
     rmarkdown,
     tibble,
     palmerpenguins,
+    mirai,
+    mori,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/forde.R
+++ b/R/forde.R
@@ -191,6 +191,15 @@ forde <- function(
   
   # Compute leaf bounds and coverage
   num_trees <- arf$num.trees
+  # Experimental opt-in backend: getOption('arf.backend') == 'mirai'
+  # routes the per-tree loops through mirai_map + mori shared memory.
+  # Default 'foreach' leaves the original code path untouched.
+  backend <- getOption('arf.backend', 'foreach')
+  use_mirai <- identical(backend, 'mirai') && isTRUE(parallel)
+  if (use_mirai) {
+    arf_check_mirai_ready()
+    mirai::everywhere(library(data.table))
+  }
   bnd_fn <- function(tree) {
     num_nodes <- length(arf$forest$split.varIDs[[tree]])
     lb <- matrix(-Inf, nrow = num_nodes, ncol = d)
@@ -226,7 +235,15 @@ forde <- function(
                id.vars = c('tree', 'leaf'), value.name = 'max'), 
           by = c('tree', 'leaf', 'variable'), sort = FALSE)
   }
-  if (isTRUE(parallel)) {
+  if (use_mirai) {
+    forest_slice <- mori::share(
+      arf$forest[c('split.varIDs', 'child.nodeIDs', 'split.values')])
+    x_shared <- mori::share(x)
+    bnds <- arf_mirai_tree_map(num_trees, arf_bnd_fn, list(
+      forest = forest_slice, d = d, finite_bounds = finite_bounds,
+      factor_cols = factor_cols, x = x_shared, epsilon = epsilon,
+      colnames_x = colnames_x))
+  } else if (isTRUE(parallel)) {
     bnds <- foreach(tree = seq_len(num_trees), .combine = rbind) %dopar% bnd_fn(tree)
   } else {
     bnds <- foreach(tree = seq_len(num_trees), .combine = rbind) %do% bnd_fn(tree)
@@ -263,6 +280,13 @@ forde <- function(
   
   # Calculate distribution parameters for each variable
   setnames(x, colnames_x)
+  if (use_mirai) {
+    pred_shared <- mori::share(pred)
+    bnds_shared <- mori::share(bnds)
+    inbag_shared <- if (!is.null(arf$inbag.counts)) {
+      mori::share(arf$inbag.counts)
+    } else NULL
+  }
   # Continuous case
   if (any(!factor_cols)) {
     psi_cnt_fn <- function(tree) {
@@ -315,7 +339,13 @@ forde <- function(
       }
       return(unique(dt[, c('tree', 'leaf', 'value') := NULL]))
     }
-    if (isTRUE(parallel)) {
+    if (use_mirai) {
+      psi_cnt <- arf_mirai_tree_map(num_trees, arf_psi_cnt_fn, list(
+        x = x_shared, factor_cols = factor_cols, pred = pred_shared,
+        inbag.counts = inbag_shared, n = n, oob = oob,
+        bnds = bnds_shared, finite_bounds = finite_bounds,
+        epsilon = epsilon, family = family))
+    } else if (isTRUE(parallel)) {
       psi_cnt <- foreach(tree = seq_len(num_trees), .combine = rbind) %dopar% 
         psi_cnt_fn(tree)
     } else {
@@ -393,7 +423,12 @@ forde <- function(
       setcolorder(dt, c("f_idx", "variable", "val", "prob", "NA_share"))
       dt
     }
-    if (isTRUE(parallel)) {
+    if (use_mirai) {
+      psi_cat <- arf_mirai_tree_map(num_trees, arf_psi_cat_fn, list(
+        x = x_shared, factor_cols = factor_cols, pred = pred_shared,
+        bnds = bnds_shared, oob = oob,
+        lvl_df_rf = mori::share(lvl_df_rf), alpha = alpha))
+    } else if (isTRUE(parallel)) {
       psi_cat <- foreach(tree = seq_len(num_trees), .combine = rbind) %dopar% 
         psi_cat_fn(tree)
     } else {

--- a/R/forde.R
+++ b/R/forde.R
@@ -198,7 +198,9 @@ forde <- function(
   use_mirai <- identical(backend, 'mirai') && isTRUE(parallel)
   if (use_mirai) {
     arf_check_mirai_ready()
-    mirai::everywhere(library(data.table))
+    # Load (not attach) data.table on every daemon so its S3 methods
+    # (e.g. `[.data.table`) are registered for the worker bodies.
+    mirai::everywhere(requireNamespace('data.table', quietly = TRUE))
   }
   bnd_fn <- function(tree) {
     num_nodes <- length(arf$forest$split.varIDs[[tree]])

--- a/R/forde_workers.R
+++ b/R/forde_workers.R
@@ -1,0 +1,213 @@
+#' @keywords internal
+#' @noRd
+
+# Per-tree worker bodies extracted from forde() so foreach and mirai
+# backends share one definition. All dependencies are explicit
+# arguments; nothing captured from enclosing scope. This is what makes
+# the mirai backend possible — daemons run in clean environments.
+
+# Worker 1: compute leaf bounds for one tree.
+arf_bnd_fn <- function(tree, forest, d, finite_bounds, factor_cols,
+                       x, epsilon, colnames_x) {
+  # data.table NSE silencing
+  variable <- NULL  # nolint
+
+  num_nodes <- length(forest$split.varIDs[[tree]])
+  lb <- matrix(-Inf, nrow = num_nodes, ncol = d)
+  ub <- matrix(Inf, nrow = num_nodes, ncol = d)
+  if (finite_bounds == "global" && any(!factor_cols)) {
+    for (j in which(!factor_cols)) {
+      min_j <- min(x[[j]], na.rm = TRUE)
+      max_j <- max(x[[j]], na.rm = TRUE)
+      gap <- max_j - min_j
+      lb[, j] <- min_j - epsilon / 2 * gap
+      ub[, j] <- max_j + epsilon / 2 * gap
+    }
+  }
+  for (i in seq_len(num_nodes)) {
+    left_child <- forest$child.nodeIDs[[tree]][[1]][i] + 1L
+    right_child <- forest$child.nodeIDs[[tree]][[2]][i] + 1L
+    splitvarID <- forest$split.varIDs[[tree]][i] + 1L
+    splitval <- forest$split.values[[tree]][i]
+    if (left_child > 1) {
+      ub[left_child, ] <- ub[right_child, ] <- ub[i, ]
+      lb[left_child, ] <- lb[right_child, ] <- lb[i, ]
+      if (left_child != right_child) {
+        ub[left_child, splitvarID] <- lb[right_child, splitvarID] <- splitval
+      }
+    }
+  }
+  leaves <- which(forest$child.nodeIDs[[tree]][[1]] == 0L)
+  colnames(lb) <- colnames(ub) <- colnames_x
+  data.table::merge.data.table(
+    data.table::melt(
+      data.table::data.table(tree = tree, leaf = leaves,
+                             lb[leaves, , drop = FALSE]),
+      id.vars = c("tree", "leaf"), value.name = "min"),
+    data.table::melt(
+      data.table::data.table(tree = tree, leaf = leaves,
+                             ub[leaves, , drop = FALSE]),
+      id.vars = c("tree", "leaf"), value.name = "max"),
+    by = c("tree", "leaf", "variable"), sort = FALSE)
+}
+
+# Worker 2: compute continuous-variable distribution params for one tree.
+arf_psi_cnt_fn <- function(tree, x, factor_cols, pred, inbag.counts, n,
+                           oob, bnds, finite_bounds, epsilon, family) {
+  # data.table NSE silencing
+  leaf <- variable <- value <- min_emp <- max_emp <- length_emp <- mu <-
+    sigma <- NA_share <- new_min <- new_max <- mid <- sigma0 <- NULL  # nolint
+
+  dt <- data.table::data.table(x[, !factor_cols, drop = FALSE],
+                               leaf = pred[, tree])
+  if (isTRUE(oob)) {
+    dt <- dt[inbag.counts[[tree]][1:n] == 0L, ]
+    dt <- dt[!is.na(leaf)]
+  } else if (identical(oob, "inbag")) {
+    dt <- dt[inbag.counts[[tree]][1:n] > 0L, ]
+    dt <- dt[!is.na(leaf)]
+  }
+  dt <- data.table::melt(dt, id.vars = "leaf",
+                         variable.factor = FALSE)[, tree := tree]
+  dt <- data.table::merge.data.table(
+    dt,
+    bnds[, .(tree, leaf, variable, min, max, f_idx)],
+    by = c("tree", "leaf", "variable"), sort = FALSE)
+  if (finite_bounds == "local") {
+    dt[, c("min_emp", "max_emp") := .(min(value, na.rm = TRUE),
+                                       max(value, na.rm = TRUE)),
+       by = .(leaf, variable)]
+    dt[, length_emp := max_emp - min_emp]
+    length_emp_0_replace <- min(
+      dt[length_emp > 0, min(length_emp, na.rm = TRUE)],
+      max(epsilon, 1e-12))
+    dt[length_emp == 0,
+       c("min_emp", "max_emp", "length_emp") :=
+         .(min_emp - length_emp_0_replace / 2,
+           max_emp + length_emp_0_replace / 2,
+           length_emp_0_replace)]
+    dt[, c("min", "max", "min_emp", "max_emp", "length_emp") :=
+         .(data.table::fifelse(
+             !is.finite(min) & !is.na(min_emp),
+             min_emp - length_emp * (epsilon / 2), min),
+           data.table::fifelse(
+             !is.finite(max) & !is.na(max_emp),
+             max_emp + length_emp * (epsilon / 2), max),
+           NULL, NULL, NULL)]
+  }
+  if (family == "truncnorm") {
+    dt[, c("mu", "sigma", "NA_share") :=
+         .(mean(value, na.rm = TRUE),
+           stats::sd(value, na.rm = TRUE),
+           sum(is.na(value)) / .N),
+       by = .(leaf, variable)]
+    dt[, c("min_emp", "max_emp") :=
+         .(min(value, na.rm = TRUE), max(value, na.rm = TRUE)),
+       by = variable]
+    dt[NA_share == 1,
+       c("min", "max") :=
+         .(data.table::fifelse(is.infinite(min), min_emp, min),
+           data.table::fifelse(is.infinite(max), max_emp, max))]
+    dt[, c("min_emp", "max_emp") := NULL]
+    dt[NA_share == 1, mu := (max + min) / 2]
+    dt[is.na(sigma), sigma := 0]
+    if (any(dt[, sigma == 0])) {
+      dt[, new_min := data.table::fifelse(
+              !is.finite(min), min(value, na.rm = TRUE), min),
+         by = variable]
+      dt[, new_max := data.table::fifelse(
+              !is.finite(max), max(value, na.rm = TRUE), max),
+         by = variable]
+      dt[, mid := (new_min + new_max) / 2]
+      dt[, sigma0 := (new_max - mid) / stats::qnorm(0.975)]
+      # Bayesian prior: 95% mass within bounding box, df = 2.
+      # See forde.R history for derivation.
+      dt[sigma == 0, sigma := sqrt(2 / .N * sigma0^2),
+         by = .(variable, leaf)]
+      dt[, c("new_min", "new_max", "mid", "sigma0") := NULL]
+    }
+  } else if (family == "unif") {
+    dt[, NA_share := sum(is.na(value)) / .N, by = .(leaf, variable)]
+  }
+  unique(dt[, c("tree", "leaf", "value") := NULL])
+}
+
+# Worker 3: compute categorical-variable distribution params for one tree.
+arf_psi_cat_fn <- function(tree, x, factor_cols, pred, bnds, oob,
+                           lvl_df_rf, alpha) {
+  # data.table NSE silencing
+  leaf <- variable <- val <- NA_share <- count <- val_count <- k <-
+    level <- prob <- f_idx <- NULL  # nolint
+
+  dt <- data.table::data.table(x[, factor_cols, drop = FALSE],
+                               leaf = pred[, tree])
+  if (isTRUE(oob)) {
+    dt <- dt[!is.na(leaf)]
+  }
+  dt <- data.table::melt(dt, id.vars = "leaf",
+                         variable.factor = FALSE,
+                         value.factor = FALSE,
+                         value.name = "val")[, tree := tree]
+  dt[, NA_share := sum(is.na(val)) / .N, by = .(leaf, variable)]
+  dt <- dt[!(is.na(val) & NA_share != 1)]
+  if (dt[, any(NA_share == 1)]) {
+    all_na <- unique(dt[NA_share == 1, ])
+    dt <- dt[NA_share != 1, ]
+    all_na <- data.table::merge.data.table(
+      all_na, bnds[, .(tree, leaf, variable, min, max, f_idx)],
+      by = c("tree", "leaf", "variable"), sort = FALSE)
+    all_na[!is.finite(min), min := 0.5]
+    for (j in names(which(factor_cols))) {
+      all_na[!is.finite(max) & variable == j,
+             max := lvl_df_rf[variable == j, max(level)]]
+    }
+    all_na[!grepl("\\.5", min), min := min + 0.5]
+    all_na[!grepl("\\.5", max), max := max + 0.5]
+    all_na[, min := min + 0.5][, max := max - 0.5]
+    all_na <- all_na[, .(level = seq(min, max), NA_share),
+                     by = .(leaf, variable)]
+    all_na <- data.table::merge.data.table(
+      all_na, lvl_df_rf, by = c("variable", "level"))
+    all_na[, level := NULL][, tree := tree]
+    data.table::setcolorder(all_na, colnames(dt))
+    dt <- rbind(dt, all_na)
+  }
+  dt[, count := .N, by = .(leaf, variable)]
+  dt <- data.table::merge.data.table(
+    dt, bnds[, .(tree, leaf, variable, min, max, f_idx)],
+    by = c("tree", "leaf", "variable"), sort = FALSE)
+  dt[, c("tree", "leaf") := NULL]
+  if (alpha == 0) {
+    dt <- unique(dt[, prob := .N / count, by = .(f_idx, variable, val)])
+  } else {
+    dt <- unique(dt[, val_count := .N, by = .(f_idx, variable, val)])
+    dt <- data.table::merge.data.table(
+      dt, lvl_df_rf[, .(k = .N), by = variable], by = "variable")
+    dt[!is.finite(min), min := 0.5][!is.finite(max), max := k + 0.5]
+    dt[!grepl("\\.5", min), min := min + 0.5][
+      !grepl("\\.5", max), max := max + 0.5]
+    dt[, k := max - min]
+    tmp <- dt[, seq(min[1] + 0.5, max[1] - 0.5),
+              by = .(f_idx, variable)]
+    data.table::setnames(tmp, "V1", "level")
+    tmp <- data.table::merge.data.table(
+      tmp, lvl_df_rf, by = c("variable", "level"),
+      sort = FALSE)[, level := NULL]
+    tmp <- data.table::merge.data.table(
+      tmp, unique(dt[, .(f_idx, variable, count, k)]),
+      by = c("f_idx", "variable"), sort = FALSE)
+    dt <- data.table::merge.data.table(
+      tmp, dt, by = c("f_idx", "variable", "val", "count", "k"),
+      all.x = TRUE, sort = FALSE)
+    dt[is.na(val_count), val_count := 0]
+    dt[, NA_share := mean(NA_share, na.rm = TRUE),
+       by = .(f_idx, variable)]
+    dt[, prob := (val_count + alpha) / (count + alpha * k),
+       by = .(f_idx, variable, val)]
+    dt[, c("val_count", "k") := NULL]
+  }
+  dt[, c("count", "min", "max") := NULL]
+  data.table::setcolorder(dt, c("f_idx", "variable", "val", "prob",
+                                 "NA_share"))
+  dt
+}

--- a/R/mirai_helpers.R
+++ b/R/mirai_helpers.R
@@ -1,0 +1,58 @@
+#' @keywords internal
+#' @noRd
+
+# Internal helpers for the experimental mirai+mori backend.
+# Activated by getOption("arf.backend", "foreach") == "mirai".
+# Hidden from public API; mirai and mori in Suggests only.
+
+arf_check_mirai_ready <- function() {
+  if (!requireNamespace("mirai", quietly = TRUE)) {
+    stop("arf.backend = 'mirai' requires the 'mirai' package. ",
+         "Install it or set options(arf.backend = 'foreach').",
+         call. = FALSE)
+  }
+  if (!requireNamespace("mori", quietly = TRUE)) {
+    stop("arf.backend = 'mirai' requires the 'mori' package. ",
+         "Install it or set options(arf.backend = 'foreach').",
+         call. = FALSE)
+  }
+  status <- mirai::status()
+  if (is.null(status$connections) || status$connections < 1L) {
+    stop("arf.backend = 'mirai' requires daemons() to be set. ",
+         "Call mirai::daemons(n) before forde().",
+         call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+# Note: data.table objects come back from mori with truelength == 0
+# (selfref dropped by the ALTREP round-trip), but read-only operations
+# in the worker bodies tolerate this — see bench/compat/01-datatable.R.
+# No setalloccol() repair is needed because workers only read the
+# shared tables and build fresh data.tables from the results.
+
+# Dispatch a per-tree worker over mirai daemons. Trees are split into
+# one chunk per daemon; each task loops the per-tree worker over its
+# block and rbinds locally (e.g. 100 trees -> 4 tasks on 4 daemons).
+# At small scale this is timing-neutral vs one-task-per-tree, but it
+# bounds the number of result objects serialized back to n_workers
+# rather than num_trees, which matters for the large-grid cases.
+arf_mirai_tree_map <- function(num_trees, worker_fn, shared_args) {
+  st <- mirai::status()
+  n_workers <- max(1L, as.integer(st$connections))
+  n_chunks <- max(1L, min(n_workers, num_trees))
+  chunks <- split(seq_len(num_trees),
+                   rep(seq_len(n_chunks), length.out = num_trees))
+  chunk_runner <- function(trees, worker_fn, shared_args) {
+    parts <- lapply(trees, function(tr) {
+      do.call(worker_fn, c(list(tr), shared_args))
+    })
+    data.table::rbindlist(parts)
+  }
+  res <- mirai::mirai_map(
+    chunks,
+    chunk_runner,
+    .args = list(worker_fn = worker_fn, shared_args = shared_args)
+  )[]
+  data.table::rbindlist(res)
+}

--- a/tests/testthat/test-mirai-backend.R
+++ b/tests/testthat/test-mirai-backend.R
@@ -7,12 +7,13 @@ test_that("mirai backend produces equal forde output on iris", {
 
   arf <- adversarial_rf(iris, verbose = FALSE, parallel = FALSE)
 
-  withr::local_options(arf.backend = "foreach")
+  old <- options(arf.backend = "foreach")
+  on.exit(options(old), add = TRUE)
   psi_foreach <- forde(arf, iris, parallel = FALSE)
 
-  withr::local_options(arf.backend = "mirai")
+  options(arf.backend = "mirai")
   mirai::daemons(2)
-  withr::defer(mirai::daemons(0))
+  on.exit(mirai::daemons(0), add = TRUE)
   psi_mirai <- forde(arf, iris, parallel = TRUE)
 
   expect_equal(psi_mirai$cnt, psi_foreach$cnt, ignore_attr = TRUE)
@@ -26,7 +27,8 @@ test_that("mirai backend errors clearly when daemons are not set", {
 
   arf <- adversarial_rf(iris, verbose = FALSE, parallel = FALSE)
   mirai::daemons(0)
-  withr::local_options(arf.backend = "mirai")
+  old <- options(arf.backend = "mirai")
+  on.exit(options(old), add = TRUE)
 
   expect_error(forde(arf, iris, parallel = TRUE), "daemons")
 })

--- a/tests/testthat/test-mirai-backend.R
+++ b/tests/testthat/test-mirai-backend.R
@@ -1,0 +1,32 @@
+# Correctness gate for the experimental mirai+mori backend.
+# Prototype-scope: one dataset, equality vs the foreach path.
+
+test_that("mirai backend produces equal forde output on iris", {
+  skip_if_not_installed("mirai")
+  skip_if_not_installed("mori")
+
+  arf <- adversarial_rf(iris, verbose = FALSE, parallel = FALSE)
+
+  withr::local_options(arf.backend = "foreach")
+  psi_foreach <- forde(arf, iris, parallel = FALSE)
+
+  withr::local_options(arf.backend = "mirai")
+  mirai::daemons(2)
+  withr::defer(mirai::daemons(0))
+  psi_mirai <- forde(arf, iris, parallel = TRUE)
+
+  expect_equal(psi_mirai$cnt, psi_foreach$cnt, ignore_attr = TRUE)
+  expect_equal(psi_mirai$cat, psi_foreach$cat, ignore_attr = TRUE)
+  expect_equal(psi_mirai$forest, psi_foreach$forest, ignore_attr = TRUE)
+})
+
+test_that("mirai backend errors clearly when daemons are not set", {
+  skip_if_not_installed("mirai")
+  skip_if_not_installed("mori")
+
+  arf <- adversarial_rf(iris, verbose = FALSE, parallel = FALSE)
+  mirai::daemons(0)
+  withr::local_options(arf.backend = "mirai")
+
+  expect_error(forde(arf, iris, parallel = TRUE), "daemons")
+})


### PR DESCRIPTION
Parallelizing with mirai + mori allows sharing R objects in memory, meaning less overhead as data doesn't have to be copied between workers.

This will need a bit more testing but I think supporting mirai/mori is going to be a big win as the two basically redefined the modern R parallelism stack.