### PR TITLE
add configs for jarl and air (none applied yet)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@
 ^arf.*\.tgz$
 ^doc$
 ^Meta$
+^air\.toml$
+^jarl\.toml$

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 120
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,0 +1,12 @@
+# Jarl (Just Another R Linter) configuration — https://jarl.etiennebacher.com
+#
+# Division of labour: air (air.toml) owns formatting/style; jarl owns
+# correctness/quality lints. We start from jarl's default rule set and add
+# `assignment` so `<-` is enforced consistently with air. Quote style is left
+# to air, not duplicated here. Tighten later, e.g. select = ["ALL"] + ignores.
+
+[lint]
+extend-select = ["assignment"]
+
+[lint.assignment]
+operator = "<-"


### PR DESCRIPTION
Can run 

- `air format .` to auto-format all code consistently
- `jarl check .` for linting, or
- `jarl check . --fix`to auto-apply easy fixes for common code smells

I'm going to wait with applying these until other PRs are closed so that the slate is clean because the diff is going to be large 